### PR TITLE
Fix/test cannot commit log if term mismatch may split votes

### DIFF
--- a/raft/cluster_test.go
+++ b/raft/cluster_test.go
@@ -111,7 +111,7 @@ func (c *cluster) initialize(serverId uint32) {
 	}
 
 	c.listerers[serverId] = lis
-	c.logger.Debug("setup listner",
+	c.logger.Debug("setup listener",
 		zap.Uint32("id", serverId),
 		zap.String("addr", c.listerers[serverId].Addr().String()))
 

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -384,30 +384,18 @@ func TestCannotCommitLogIfTermMismatch(t *testing.T) {
 		t.Fatal("new leader should not be affected when the old leader come back")
 	}
 
-	// we disconnect all outgoing RPCs to all servers except the old leader
-	// thus forces the old leader to become the next leader
-	for i := 1; i <= numNodes; i++ {
-		id := uint32(i)
-		if id != oldLeaderId {
-			c.disconnectAll(id)
-		}
-	}
-
+	// we disconnect the current leader from the old leader, thus forces the old leader
+	// to timeout and increase term and become the next leader
+	c.disconnect(leaderId, oldLeaderId)
 	time.Sleep(1 * time.Second)
+	c.connect(leaderId, oldLeaderId)
+
 	leaderId, leaderTerm = c.checkSingleLeader()
 	if leaderId != oldLeaderId {
 		t.Fatal("leader should go back to the old leader after our manually operation")
 	}
 	if leaderTerm <= newLeaderTerm {
 		t.Fatalf("the old leader should have term %d greater than the old term", newLeaderTerm)
-	}
-
-	// resume all connections
-	for i := 1; i <= numNodes; i++ {
-		id := uint32(i)
-		if id != oldLeaderId {
-			c.connectAll(id)
-		}
 	}
 
 	// log 2 should be replicated to all servers now but cannot commit since the log does not match current term


### PR DESCRIPTION
## Description

In the `TestCannotCommitLogIfTermMismatch` test, when forcing the old leader to become the next leader, the old method may cause split votes. Since if the old leader was the last server that timeout, every other server with the same term may already voted itself thus rejecting the old leader's vote.

The new method simply make the old leader timeout then get a greater term, thus becoming the next leader.